### PR TITLE
ci: restore zread lychee checks

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -36,6 +36,4 @@ exclude = [
   '^https://notebooklm\.google\.com.*',
   '^https://www\.contributor-covenant\.org.*',
   '^https://javabetter\.cn/.*',
-  # zread.ai often returns 504/rate-limit responses from GitHub-hosted runners.
-  '^https://zread\.ai/.*',
 ]


### PR DESCRIPTION
## Summary
- Restore zread.ai Lychee link checks by removing the temporary exclusion.

## Test Plan
- make test

## Risks
- This intentionally re-enables zread.ai in GitHub link-checker; if zread.ai returns 504 again, CI may need rerun until the external service recovers.

## Links
- Add issue links, PR links, or remove this section.
