### PR TITLE
ci: restore zread lychee checks

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -36,6 +36,4 @@ exclude = [
   '^https://notebooklm\.google\.com.*',
   '^https://www\.contributor-covenant\.org.*',
   '^https://javabetter\.cn/.*',
-  # zread.ai often returns 504/rate-limit responses from GitHub-hosted runners.
-  '^https://zread\.ai/.*',
 ]


### PR DESCRIPTION
## Summary
- Restore zread.ai Lychee link checks by removing the temporary exclusion.

## Test Plan
- make test
- GitHub Actions on PR #46: markdown-lint and link-checker passed before review-gate recreation.

## Risks
- This intentionally re-enables zread.ai in GitHub link-checker; if the external service returns 504 again in future runs, CI may require rerun.

## Links
- Add issue links, PR links, or remove this section.
