### PR TITLE
docs: index harness research domain

### DIFF
--- a/assets/ai-citation/llms-full.txt
+++ b/assets/ai-citation/llms-full.txt
@@ -80,6 +80,7 @@ GEOFlow 的关键启发是：GEO 不是关键词堆砌，而是内容工程链�
 - docs/research/research-domain-contract.md：研究域的结构、raw 原始事实层、成熟度、证据、沉淀和归档规则。
 - docs/research/research-value-application-map.md：研究体系给用户带来的价值、核心启示、应用位置和下沉路线。
 - docs/research/research-transfer-synthesis.md：将对标拆解、改良迭代和杂交创新转成可执行研究路线。
+- docs/research/harness/README.md：Harness Engineering 的工程控制、评估器与反馈闭环研究对象。
 - docs/research/harness/harness-engineering.md：Harness Engineering 的工程控制、评估器与反馈闭环解析。
 - docs/research/aider-ai-aider/README.md：终端 AI 结对编程工具研究对象。
 - docs/research/aider-ai-aider/analysis.md：Aider-AI/aider 的结构化研究结论、可借鉴点、风险和下一轮任务。

--- a/metadata/taxonomy.yml
+++ b/metadata/taxonomy.yml
@@ -175,6 +175,9 @@ documents:
   - path: docs/research/research-transfer-synthesis.md
     title: 研究迁移综合
     role: 将对标拆解、改良迭代和杂交创新转成可执行研究路线
+  - path: docs/research/harness/README.md
+    title: Harness 研究对象
+    role: 工程控制、评估器、反馈闭环与 AI 生成系统可靠性研究对象
   - path: docs/research/harness/harness-engineering.md
     title: Harness 工程解析
     role: 工程控制、评估器、反馈闭环与 AI 生成系统可靠性


### PR DESCRIPTION
## Summary
- Add the Harness research domain README to metadata taxonomy.
- Add the Harness research domain README to the full AI citation entry list.

## Verification
- make test
- git diff --check

## Notes
- The Harness directory move already exists on develop; this PR only completes the machine-readable index entries.
